### PR TITLE
Evenly distribute toggles across the parent view

### DIFF
--- a/androidtoggleswitch/build.gradle
+++ b/androidtoggleswitch/build.gradle
@@ -7,8 +7,8 @@ ext {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.1"
 
     defaultConfig {
         minSdkVersion 16
@@ -26,7 +26,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:24.1.1'
 }
 
 apply from: 'https://raw.githubusercontent.com/blundell/release-android-library/master/android-release-aar.gradle'

--- a/androidtoggleswitch/src/main/java/belka/us/androidtoggleswitch/widgets/BaseToggleSwitch.java
+++ b/androidtoggleswitch/src/main/java/belka/us/androidtoggleswitch/widgets/BaseToggleSwitch.java
@@ -11,6 +11,7 @@ import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -181,13 +182,17 @@ public abstract class BaseToggleSwitch extends LinearLayout implements View.OnCl
         TextView toggleBtnTxt = toggleSwitchButton.getTextView();
         toggleBtnTxt.setText(text);
         toggleBtnTxt.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize);
-        toggleBtnTxt.setLayoutParams(new LayoutParams((int) toggleWidth, LayoutParams.WRAP_CONTENT));
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams((int) toggleWidth, LayoutParams.WRAP_CONTENT);
+        if (toggleWidth == 0f) params.weight = 1f;
+        toggleBtnTxt.setLayoutParams(params);
 
         toggleSwitchButton.getSeparator().setBackgroundColor(separatorColor);
 
         toggleSwitchButton.getTextView().setOnClickListener(this);
 
-        toggleSwitchesContainer.addView(toggleSwitchButton.getView());
+        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams((int) toggleWidth, LayoutParams.MATCH_PARENT);
+        if (toggleWidth == 0f) layoutParams.weight = 1f;
+        toggleSwitchesContainer.addView(toggleSwitchButton.getView(), layoutParams);
 
         // Disable last added button
         disable(toggleSwitchesContainer.getChildCount() - 1);

--- a/androidtoggleswitch/src/main/res/layout/activity_main.xml
+++ b/androidtoggleswitch/src/main/res/layout/activity_main.xml
@@ -1,16 +1,11 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:paddingLeft="@dimen/activity_horizontal_margin"
-                android:paddingRight="@dimen/activity_horizontal_margin"
-                android:paddingTop="@dimen/activity_vertical_margin"
-                android:paddingBottom="@dimen/activity_vertical_margin"
-                tools:context=".MainActivity">
-
-    <TextView
-        android:text="@string/hello_world"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context=".MainActivity">
 
 </RelativeLayout>

--- a/androidtoggleswitch/src/main/res/layout/item_widget_toggle_switch.xml
+++ b/androidtoggleswitch/src/main/res/layout/item_widget_toggle_switch.xml
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="0dp"
+    android:layout_height="match_parent"
     android:clickable="true"
     android:orientation="horizontal">
 
     <TextView
         android:id="@+id/text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
-        android:layout_width="64dp"
-        android:layout_height="wrap_content"
         android:gravity="center"
         android:paddingBottom="@dimen/space.small"
         android:paddingLeft="@dimen/space.medium"
         android:paddingRight="@dimen/space.medium"
         android:paddingTop="@dimen/space.small"
-        android:textAllCaps="true"/>
+        android:textAllCaps="true" />
 
     <View
         android:id="@+id/separator"
         android:layout_width="1dp"
         android:layout_height="match_parent"
-        android:visibility="invisible"
+        android:layout_marginBottom="@dimen/space.very_small"
         android:layout_marginTop="@dimen/space.very_small"
-        android:layout_marginBottom="@dimen/space.very_small"/>
+        android:visibility="invisible" />
 
 </LinearLayout>


### PR DESCRIPTION
Setting toggleWidth to 0dp will also automatically set each toggle’s layout_weight attribute to 1 such that all toggles will be evenly distributed in the parent view. Behavior will remain as it used to be if toggleWidth is any other value.

This fixes #13 
